### PR TITLE
Use suggested syntax for noarch python in recipe

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -6,3 +6,5 @@ channel_targets:
 - conda-forge main
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
+python_min:
+- '3.9'

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @bdice @gmarkall @vyasr
+* @bdice @gmarkall @kkraus14 @vyasr

--- a/README.md
+++ b/README.md
@@ -151,5 +151,6 @@ Feedstock Maintainers
 
 * [@bdice](https://github.com/bdice/)
 * [@gmarkall](https://github.com/gmarkall/)
+* [@kkraus14](https://github.com/kkraus14/)
 * [@vyasr](https://github.com/vyasr/)
 

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -18,7 +18,7 @@ build:
 
 requirements:
   host:
-    - python ${{ python_min }}
+    - python ${{ python_min }}.*
     - pip
     - setuptools
   run:

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -18,18 +18,21 @@ build:
 
 requirements:
   host:
-    - python ${{ python_min }}
+    - python {{ python_min }}
     - pip
     - setuptools
   run:
-    - python >=${{ python_min }}
+    - python >={{ python_min }}
     - numba >=0.59.1
 
-tests:
-  - python:
-      imports:
-      - numba_cuda
-      pip_check: true
+test:
+  requires:
+    - python {{ python_min }}
+    - pip
+  imports:
+    - numba_cuda
+  commands:
+    - pip check
 
 about:
   homepage: https://github.com/NVIDIA/numba-cuda
@@ -46,3 +49,4 @@ extra:
     - bdice
     - gmarkall
     - vyasr
+    - kkraus14

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -2,6 +2,7 @@ context:
   name: numba-cuda
   sdist_name: numba_cuda
   version: "0.5.0"
+  python_min: "3.9"
 
 package:
   name: ${{ name }}
@@ -18,11 +19,11 @@ build:
 
 requirements:
   host:
-    - python >=3.9
+    - python ${{ python_min }}
     - pip
     - setuptools
   run:
-    - python >=3.9
+    - python >=${{ python_min }}
     - numba >=0.59.1
 
 tests:

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -2,7 +2,6 @@ context:
   name: numba-cuda
   sdist_name: numba_cuda
   version: "0.5.0"
-  python_min: "3.9"
 
 package:
   name: ${{ name }}

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -15,7 +15,7 @@ source:
 build:
   noarch: python
   script: python -m pip install . -vv
-  number: 0
+  number: 1
 
 requirements:
   host:

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -18,11 +18,11 @@ build:
 
 requirements:
   host:
-    - python {{ python_min }}
+    - python ${{ python_min }}
     - pip
     - setuptools
   run:
-    - python >={{ python_min }}
+    - python >=${{ python_min }}
     - numba >=0.59.1
 
 tests:

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -30,6 +30,7 @@ tests:
       imports:
         - numba_cuda
       pip_check: true
+      python_version: ${{ python_min }}.*
 
 about:
   homepage: https://github.com/NVIDIA/numba-cuda


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [ ] ~~Reset the build number to `0` (if the version changed)~~
* [X] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

I'm trying to follow the guidelines always suggested by the linter for the Python version (e.g. [in this comment](https://github.com/conda-forge/numba-cuda-feedstock/pull/12#issuecomment-2671338688)), but I'm not quite sure I'm getting it right.

Rerendering with just the change to the `host` and run sections results in conda-smithy failing to parse the recipe, because it looks like `${{ python_min }}` evaluates to nothing:

```
Error:   × Failed to parse recipe

Error:   × Parsing: failed to parse match spec: unable to parse version spec: >=
    ╭─[25:7]
 24 │   run:
 25 │     - python >=${{ python_min }}
    ·       ─────────────┬────────────
    ·                    ╰── error parsing `python >=` as a match spec
 26 │     - numba >=0.59.1
    ╰────
```

Rerendering with

```
python_min:
- "3.9"
```

in a new file, `recipe/conda_build_config.yaml` results in a similar issue:

```
Adding in variants from internal_defaults
Adding in variants from /home/gmarkall/.cache/conda-smithy/conda_build_config.yaml
Adding in variants from /home/gmarkall/conda-forge/numba-cuda-feedstock/recipe/conda_build_config.yaml
Error:   × Failed to parse recipe

Error:   × Parsing: failed to parse match spec: unable to parse version spec: >=
    ╭─[25:7]
 24 │   run:
 25 │     - python >=${{ python_min }}
    ·       ─────────────┬────────────
    ·                    ╰── error parsing `python >=` as a match spec
 26 │     - numba >=0.59.1
    ╰────
```

Therefore, I added `python_min: "3.9"` to the `context` section, which seems to succeed, but feels wrong. I think ideally that wouldn't be required, and the default minimum supported version on conda-forge should just be used.

Any thoughts on what I'm doing wrong, @bdice / @jakirkham?
<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
