### PR TITLE
Add `packaging` to latest run deps

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -13,7 +13,7 @@ source:
 
 build:
   script: python -m pip install . -vv
-  number: 0
+  number: 1
   skip: [osx]
 
 requirements:
@@ -35,6 +35,7 @@ requirements:
     - cuda-cudart-dev
     - cuda-version >=12
     - cuda-nvcc-impl
+    - packaging
 
 tests:
   - python:


### PR DESCRIPTION
`numba-cuda` should depend on `packaging` from. 0.23.x forward as it relies on the same fixes