### PR TITLE
fix: remove stdlib syntax that is unparsable by pixi

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -61,4 +61,3 @@ extra:
     - gmarkall
     - vyasr
     - kkraus14
-    - cpcloud


### PR DESCRIPTION
Remove stdlib bit that is unparsable by pixi, and add cpcloud as maintainer